### PR TITLE
feat: migrate Zendesk authentication to OAuth client credentials

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,13 +1,21 @@
-# the following are only used for the webhook setup script and the nextjs app
+# ============ ZENDESK AUTHENTICATION ============
+# Required Zendesk account subdomain and confidential OAuth client credentials.
+# Use runtime scopes in Vercel and provisioning scopes when running the local scripts.
+ZENDESK_SUBDOMAIN=
+ZENDESK_OAUTH_CLIENT_ID=
+ZENDESK_OAUTH_CLIENT_SECRET=
+
+# Optional deprecated fallback. If configured, both values must be provided together.
+# These are used only when OAuth token acquisition fails or OAuth receives a 401/403.
 ZENDESK_API_USER=
 ZENDESK_API_TOKEN=
-ZENDESK_SUBDOMAIN=
 
-
-# the following is only used for the webhook setup script only
+# ============ WEBHOOK SETUP ============
+# Used only by the local webhook lifecycle scripts.
 AI_PROCESSING_ENDPOINT=https://<your-endpoint>/api/webhook
 
-# the following are only used for the nextjs app
+# ============ APPLICATION ============
+# Used only by the Next.js application.
 AUTO_RESPONDER_INKEEP_API_KEY=
 INTERNAL_ONLY=true
 AI_TRIAGE_ENABLED=false

--- a/README.md
+++ b/README.md
@@ -82,7 +82,17 @@ cp .env.sample .env
 - `AI_AGENT_USER_ID`: The User ID you'd like the AI bot to have if leaving internal comments
 - `ENABLE_PUBLIC_RESPONSES`: Set to `true` to make AI responses visible to customers (defaults to `false` where all responses are internal comments)
 
-The application and local scripts obtain a new short-lived OAuth access token immediately before each Zendesk API operation, following Zendesk's client-credentials example. They do not reuse, store, refresh, or track the expiry of access tokens. If both deprecated API-token variables are configured, they fall back to them only when OAuth token acquisition fails or Zendesk rejects OAuth with a `401` or `403`. Every fallback emits a warning in the logs.
+Before each Zendesk API call, the Vercel application gets a new OAuth token. It does not store or refresh tokens. If Zendesk returns a server error while issuing a token, the application retries three times and logs each retry. If OAuth still fails and the old API credentials are configured, the application uses them and logs a warning.
+
+### Rolling Out OAuth from a Working API Token
+
+The existing webhook and trigger do not need to change.
+
+1. Create the OAuth client. Add `ZENDESK_OAUTH_CLIENT_ID` and `ZENDESK_OAUTH_CLIENT_SECRET` to Vercel. Keep the old API credentials in Vercel for now, then deploy.
+2. Create a test ticket. Make sure the application adds the expected reply or internal note. Check the Vercel logs. If the old API token was used, you will see `Zendesk OAuth ...; using deprecated API-token fallback`.
+3. Remove `ZENDESK_API_USER` and `ZENDESK_API_TOKEN` from Vercel and deploy again. Do not revoke the API token in Zendesk yet. This makes it easy to add the old credentials back if something goes wrong.
+4. Create another test ticket. If it works, let the application run normally for a few days and make sure tickets keep getting replies.
+5. Revoke the old API token in Zendesk.
 
 ### Step 4: Install Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -31,15 +31,35 @@ graph LR
 
 Follow these steps in order to set up the Zendesk AI Auto Responder:
 
-### Step 1: Deploy Template to Vercel
+> **Note:** Zendesk is removing API tokens as an authentication method. Starting July 28, 2026, tokens unused for 30 days will be automatically deleted. By April 30, 2027, all API tokens will stop working. You must [migrate your integrations to OAuth access tokens](https://developer.zendesk.com/documentation/api-basics/authentication/oauth-migration/) before the final deadline. This change only affects APIs that currently use API tokens including the Ticketing, Help Center, and Voice APIs. It does not apply to other Zendesk products. See [Managing API token access to the Zendesk API](https://support.zendesk.com/hc/en-us/articles/4408889192858-Managing-API-token-access-to-the-Zendesk-API).
+
+### Step 1: Create Zendesk OAuth Clients
+
+In Zendesk Admin Center, go to **Apps and integrations > APIs > OAuth clients** and create a confidential OAuth client.
+
+The deployed application requests these least-privilege scopes:
+
+```text
+tickets:read tickets:write users:read organizations:read
+```
+
+The local setup scripts manage account configuration and request these scopes:
+
+```text
+webhooks:read webhooks:write triggers:read triggers:write
+```
+
+For least privilege, use separate OAuth clients for the deployed runtime and local provisioning scripts. They use the same environment variable names in their respective Vercel and local environments. Store each client secret securely; Zendesk shows it only when the client is created.
+
+### Step 2: Deploy Template to Vercel
 
 1. **Deploy to Vercel** using the button below:
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Finkeep%2Fzendesk-inkeep-template&env=ZENDESK_SUBDOMAIN,ZENDESK_API_TOKEN,ZENDESK_API_USER,AUTO_RESPONDER_INKEEP_API_KEY&envDescription=API%20keys%20required%20for%20successful%20deployment&project-name=zendesk-inkeep-autoresponder&repository-name=zendesk-inkeep-autoresponder)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Finkeep%2Fzendesk-inkeep-template&env=ZENDESK_SUBDOMAIN,ZENDESK_OAUTH_CLIENT_ID,ZENDESK_OAUTH_CLIENT_SECRET,AUTO_RESPONDER_INKEEP_API_KEY,ZENDESK_WEBHOOK_SECRET&envDescription=OAuth%20credentials%20and%20API%20keys%20required%20for%20successful%20deployment&project-name=zendesk-inkeep-autoresponder&repository-name=zendesk-inkeep-autoresponder)
 
 **Important:** During Vercel deployment, you'll be prompted for environment variables. However, these are only used by the deployed app - you'll still need to configure them locally for the setup script.
 
-### Step 2: Clone Locally and Configure Environment
+### Step 3: Clone Locally and Configure Environment
 
 1. Create an environment file by copying the sample:
 ```bash
@@ -50,23 +70,27 @@ cp .env.sample .env
 
 **Required variables:**
 - `ZENDESK_SUBDOMAIN`: Your Zendesk subdomain (e.g., if your Zendesk URL is mycompany.zendesk.com, enter 'mycompany')
-- `ZENDESK_API_TOKEN`: Generate at [Zendesk API token docs](https://support.zendesk.com/hc/en-us/articles/4408889192858-Generating-a-new-API-token)
-- `ZENDESK_API_USER`: Email address of your Zendesk user
+- `ZENDESK_OAUTH_CLIENT_ID`: Identifier of your confidential Zendesk OAuth client
+- `ZENDESK_OAUTH_CLIENT_SECRET`: Secret of your confidential Zendesk OAuth client
 - `ZENDESK_WEBHOOK_SECRET`: A secret key for webhook security [docs](https://developer.zendesk.com/documentation/webhooks/verifying/)
 - `AI_PROCESSING_ENDPOINT`: Your Vercel deployment URL + `/api/webhook` (e.g., `https://your-app-name.vercel.app/api/webhook`)
 - `AUTO_RESPONDER_INKEEP_API_KEY`: Your Inkeep API key (you must have an account at https://portal.inkeep.com)
 
 **Optional variables:**
+- `ZENDESK_API_USER`: Deprecated API-token user email, accepted temporarily as an OAuth migration fallback
+- `ZENDESK_API_TOKEN`: Deprecated API token; must be provided together with `ZENDESK_API_USER`
 - `AI_AGENT_USER_ID`: The User ID you'd like the AI bot to have if leaving internal comments
 - `ENABLE_PUBLIC_RESPONSES`: Set to `true` to make AI responses visible to customers (defaults to `false` where all responses are internal comments)
 
-### Step 3: Install Prerequisites
+The application and local scripts obtain a new short-lived OAuth access token immediately before each Zendesk API operation, following Zendesk's client-credentials example. They do not reuse, store, refresh, or track the expiry of access tokens. If both deprecated API-token variables are configured, they fall back to them only when OAuth token acquisition fails or Zendesk rejects OAuth with a `401` or `403`. Every fallback emits a warning in the logs.
+
+### Step 4: Install Prerequisites
 
 **Install jq** (required for the setup script):
 - **macOS**: `brew install jq`
 - **Windows**: Download from [jq website](https://jqlang.github.io/jq/download/)
 
-### Step 4 : Run Setup Script
+### Step 5: Run Setup Script
 
 Run the setup script to create the Zendesk webhook and trigger:
 ```bash
@@ -83,9 +107,10 @@ chmod +x ./webhook_setup/setup.sh
 
 **Possible causes:**
 1. **Missing environment variables** - Ensure all required variables are set in your `.env` file
-2. **Invalid API credentials** - Verify your `ZENDESK_API_USER` and `ZENDESK_API_TOKEN` are correct
-3. **Wrong subdomain** - Double-check your `ZENDESK_SUBDOMAIN` value
-4. **Incorrect endpoint URL** - Ensure `AI_PROCESSING_ENDPOINT` is your Vercel URL + `/api/webhook`
+2. **Invalid OAuth credentials** - Verify your OAuth client is confidential and its identifier and secret are correct
+3. **Insufficient OAuth scopes** - Verify the local client can request `webhooks:read webhooks:write triggers:read triggers:write`
+4. **Wrong subdomain** - Double-check your `ZENDESK_SUBDOMAIN` value
+5. **Incorrect endpoint URL** - Ensure `AI_PROCESSING_ENDPOINT` is your Vercel URL + `/api/webhook`
 
 **Solution:** Check the setup script output for error messages and verify your `.env` configuration.
 

--- a/src/app/api/webhook/route.ts
+++ b/src/app/api/webhook/route.ts
@@ -1,5 +1,4 @@
 import { z } from 'zod';
-import { createClient } from 'node-zendesk';
 import { generateQaModeResponse } from '@/lib/intelligent-support/support';
 import type { ZendeskMessage } from '@/lib/zendeskConversations';
 import type { CreateOrUpdateTicket } from 'node-zendesk/clients/core/tickets';
@@ -10,16 +9,10 @@ import { aiTriageTicket, formatTriageComment } from '@/lib/ticket-routing/ai';
 import crypto from 'node:crypto';
 import type { Messages, UserProperties } from '@inkeep/inkeep-analytics/models/components';
 import { logToInkeepAnalytics } from '@/lib/analytics/logToInkeepAnalytics';
+import { createZendeskClientProvider } from '@/lib/zendeskClient';
 
 // Timeout of the Serverless Function. Increase if adding multiple AI steps. Check your Vercel plan.
 export const maxDuration = 60;
-
-// Initialize Zendesk client
-const client = createClient({
-  username: process.env.ZENDESK_API_USER!,
-  token: process.env.ZENDESK_API_TOKEN!,
-  subdomain: process.env.ZENDESK_SUBDOMAIN!,
-});
 
 // Add these constants at the top of the file
 const SIGNING_SECRET = process.env.ZENDESK_WEBHOOK_SECRET!;
@@ -83,15 +76,17 @@ export const POST = async (req: Request) => {
   const { ticket_id } = result.data;
 
   try {
+    const zendesk = await createZendeskClientProvider();
+
     // Fetch ticket details and comments
     const [ticketResponse, commentsResponse] = await Promise.all([
-      client.tickets.show(ticket_id),
-      client.tickets.getComments(ticket_id),
+      zendesk.run(client => client.tickets.show(ticket_id)),
+      zendesk.run(client => client.tickets.getComments(ticket_id)),
     ]);
 
     // Get user and their organization details
     const requesterId = ticketResponse.result.requester_id;
-    const userDetailsResponse = await client.users.show(requesterId)
+    const userDetailsResponse = await zendesk.run(client => client.users.show(requesterId));
 
     // Initialize properties for logging to Inkeep Analytics
     const messagesToLogToAnalytics: Messages[] = [];
@@ -110,8 +105,11 @@ export const POST = async (req: Request) => {
 
     // If user belongs to an organization, fetch org details
     let orgDetails = null;
-    if (userDetailsResponse.result.organization_id) {
-      orgDetails = (await client.organizations.show(userDetailsResponse.result.organization_id)) as any;
+    const organizationId = userDetailsResponse.result.organization_id;
+    if (organizationId) {
+      orgDetails = (await zendesk.run(client =>
+        client.organizations.show(organizationId),
+      )) as any;
     }
 
     // Access user and org metadata
@@ -127,7 +125,7 @@ export const POST = async (req: Request) => {
     // Fetch all unique authors in parallel
     await Promise.all(
       authorIds.map(async authorId => {
-        const authorResponse = await client.users.show(authorId);
+        const authorResponse = await zendesk.run(client => client.users.show(authorId));
         authorCache.set(authorId, authorResponse.result);
       }),
     );
@@ -203,15 +201,17 @@ export const POST = async (req: Request) => {
 
           const triageComment = formatTriageComment(aiTriageData);
 
-          await client.tickets.update(ticket_id, {
-            ticket: {
-              comment: {
-                body: triageComment,
-                public: false, // only ever meant to be an internal note (not visible to the customer)
-                ...(author_id && { author_id }),
+          await zendesk.run(client =>
+            client.tickets.update(ticket_id, {
+              ticket: {
+                comment: {
+                  body: triageComment,
+                  public: false, // only ever meant to be an internal note (not visible to the customer)
+                  ...(author_id && { author_id }),
+                },
               },
-            },
-          } as CreateOrUpdateTicket);
+            } as CreateOrUpdateTicket),
+          );
 
           messagesToLogToAnalytics.push({
             content: triageComment,
@@ -234,15 +234,17 @@ export const POST = async (req: Request) => {
       switch (response.aiAnnotations.answerConfidence) {
         case 'very_confident': {
           console.log(`Posting ${isPublicResponsesEnabled ? 'public' : 'internal [ENABLE_PUBLIC_RESPONSES is off]'} comment to ticket ${ticket_id}`);
-          await client.tickets.update(ticket_id, {
-            ticket: {
-              comment: {
-                body: response.text,
-                public: isPublicResponsesEnabled,
-                ...(author_id && { author_id }),
+          await zendesk.run(client =>
+            client.tickets.update(ticket_id, {
+              ticket: {
+                comment: {
+                  body: response.text,
+                  public: isPublicResponsesEnabled,
+                  ...(author_id && { author_id }),
+                },
               },
-            },
-          } as CreateOrUpdateTicket);
+            } as CreateOrUpdateTicket),
+          );
 
           messagesToLogToAnalytics.push({
             content: response.text,
@@ -254,15 +256,17 @@ export const POST = async (req: Request) => {
         default: {
           console.log(`Adding low confidence note to ticket ${ticket_id}`);
           const confidenceNote = `AI Agent had ${response.aiAnnotations.answerConfidence} confidence level in its answer`;
-          await client.tickets.update(ticket_id, {
-            ticket: {
-              comment: {
-                body: confidenceNote,
-                public: false,
-                ...(author_id && { author_id }),
+          await zendesk.run(client =>
+            client.tickets.update(ticket_id, {
+              ticket: {
+                comment: {
+                  body: confidenceNote,
+                  public: false,
+                  ...(author_id && { author_id }),
+                },
               },
-            },
-          } as CreateOrUpdateTicket);
+            } as CreateOrUpdateTicket),
+          );
 
           messagesToLogToAnalytics.push({
             content: confidenceNote,

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,0 +1,46 @@
+import { z } from 'zod';
+
+const optionalEnvironmentValue = z.preprocess(
+  value => value === '' ? undefined : value,
+  z.string().min(1).optional(),
+);
+
+const zendeskEnvSchema = z
+  .object({
+    ZENDESK_SUBDOMAIN: z
+      .string()
+      .min(1)
+      .describe('Zendesk account subdomain used for API requests'),
+    ZENDESK_OAUTH_CLIENT_ID: z
+      .string()
+      .min(1)
+      .describe('Required identifier for the confidential Zendesk OAuth client'),
+    ZENDESK_OAUTH_CLIENT_SECRET: z
+      .string()
+      .min(1)
+      .describe('Required secret for the confidential Zendesk OAuth client'),
+    ZENDESK_API_USER: optionalEnvironmentValue
+      .describe('Deprecated Zendesk API user email used only as an OAuth migration fallback'),
+    ZENDESK_API_TOKEN: optionalEnvironmentValue
+      .describe('Deprecated Zendesk API token used only as an OAuth migration fallback'),
+  })
+  .superRefine((env, ctx) => {
+    if (Boolean(env.ZENDESK_API_USER) !== Boolean(env.ZENDESK_API_TOKEN)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'ZENDESK_API_USER and ZENDESK_API_TOKEN must be provided together',
+      });
+    }
+  });
+
+export type ZendeskEnv = z.infer<typeof zendeskEnvSchema>;
+
+export function getZendeskEnv(): ZendeskEnv {
+  return zendeskEnvSchema.parse({
+    ZENDESK_SUBDOMAIN: process.env.ZENDESK_SUBDOMAIN,
+    ZENDESK_OAUTH_CLIENT_ID: process.env.ZENDESK_OAUTH_CLIENT_ID,
+    ZENDESK_OAUTH_CLIENT_SECRET: process.env.ZENDESK_OAUTH_CLIENT_SECRET,
+    ZENDESK_API_USER: process.env.ZENDESK_API_USER,
+    ZENDESK_API_TOKEN: process.env.ZENDESK_API_TOKEN,
+  });
+}

--- a/src/lib/zendeskClient.ts
+++ b/src/lib/zendeskClient.ts
@@ -4,6 +4,8 @@ import { getZendeskEnv, type ZendeskEnv } from '@/env';
 
 const ZENDESK_RUNTIME_SCOPE =
   'tickets:read tickets:write users:read organizations:read';
+const MAX_TOKEN_RETRIES = 3;
+const TOKEN_RETRY_BASE_DELAY_MS = 250;
 
 const tokenResponseSchema = z.object({
   access_token: z.string().min(1),
@@ -54,7 +56,11 @@ function isOAuthAuthorizationError(error: unknown): boolean {
   return error instanceof Error && /\b(?:401|403)\b/.test(error.message);
 }
 
-async function requestOAuthAccessToken(env: ZendeskEnv): Promise<string> {
+function delay(milliseconds: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, milliseconds));
+}
+
+async function requestOAuthAccessTokenOnce(env: ZendeskEnv): Promise<string> {
   const body = new URLSearchParams({
     grant_type: 'client_credentials',
     client_id: env.ZENDESK_OAUTH_CLIENT_ID,
@@ -70,7 +76,9 @@ async function requestOAuthAccessToken(env: ZendeskEnv): Promise<string> {
   });
 
   if (!response.ok) {
-    throw new Error(`Zendesk OAuth token request failed with status ${response.status}`);
+    const error = new Error(`Zendesk OAuth token request failed with status ${response.status}`);
+    Object.assign(error, { status: response.status });
+    throw error;
   }
 
   const result = tokenResponseSchema.safeParse(await response.json());
@@ -79,6 +87,28 @@ async function requestOAuthAccessToken(env: ZendeskEnv): Promise<string> {
   }
 
   return result.data.access_token;
+}
+
+async function requestOAuthAccessToken(env: ZendeskEnv): Promise<string> {
+  for (let attempt = 0; attempt <= MAX_TOKEN_RETRIES; attempt += 1) {
+    try {
+      return await requestOAuthAccessTokenOnce(env);
+    } catch (error) {
+      const status = getStatusCode(error);
+      const isServerError = status !== undefined && status >= 500 && status < 600;
+      if (!isServerError || attempt === MAX_TOKEN_RETRIES) {
+        throw error;
+      }
+
+      const retryNumber = attempt + 1;
+      console.warn(
+        `Zendesk OAuth token acquisition failed; retrying (${retryNumber}/${MAX_TOKEN_RETRIES})`,
+      );
+      await delay(TOKEN_RETRY_BASE_DELAY_MS * 2 ** attempt);
+    }
+  }
+
+  throw new Error('Zendesk OAuth token acquisition failed');
 }
 
 export interface ZendeskClientProvider {

--- a/src/lib/zendeskClient.ts
+++ b/src/lib/zendeskClient.ts
@@ -1,0 +1,138 @@
+import { createClient } from 'node-zendesk';
+import { z } from 'zod';
+import { getZendeskEnv, type ZendeskEnv } from '@/env';
+
+const ZENDESK_RUNTIME_SCOPE =
+  'tickets:read tickets:write users:read organizations:read';
+
+const tokenResponseSchema = z.object({
+  access_token: z.string().min(1),
+  expires_in: z.number().positive(),
+});
+
+type ZendeskClient = ReturnType<typeof createClient>;
+
+function createLegacyClient(env: ZendeskEnv): ZendeskClient | undefined {
+  if (!env.ZENDESK_API_USER || !env.ZENDESK_API_TOKEN) {
+    return undefined;
+  }
+
+  return createClient({
+    username: env.ZENDESK_API_USER,
+    token: env.ZENDESK_API_TOKEN,
+    subdomain: env.ZENDESK_SUBDOMAIN,
+    throwOriginalException: true,
+  });
+}
+
+function getStatusCode(error: unknown): number | undefined {
+  if (!error || typeof error !== 'object') {
+    return undefined;
+  }
+
+  const value = error as {
+    status?: unknown;
+    statusCode?: unknown;
+    response?: { status?: unknown; statusCode?: unknown };
+  };
+  const candidates = [
+    value.status,
+    value.statusCode,
+    value.response?.status,
+    value.response?.statusCode,
+  ];
+
+  return candidates.find(candidate => typeof candidate === 'number') as number | undefined;
+}
+
+function isOAuthAuthorizationError(error: unknown): boolean {
+  const statusCode = getStatusCode(error);
+  if (statusCode === 401 || statusCode === 403) {
+    return true;
+  }
+
+  return error instanceof Error && /\b(?:401|403)\b/.test(error.message);
+}
+
+async function requestOAuthAccessToken(env: ZendeskEnv): Promise<string> {
+  const body = new URLSearchParams({
+    grant_type: 'client_credentials',
+    client_id: env.ZENDESK_OAUTH_CLIENT_ID,
+    client_secret: env.ZENDESK_OAUTH_CLIENT_SECRET,
+    scope: ZENDESK_RUNTIME_SCOPE,
+  });
+  const response = await fetch(`https://${env.ZENDESK_SUBDOMAIN}.zendesk.com/oauth/tokens`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body,
+  });
+
+  if (!response.ok) {
+    throw new Error(`Zendesk OAuth token request failed with status ${response.status}`);
+  }
+
+  const result = tokenResponseSchema.safeParse(await response.json());
+  if (!result.success) {
+    throw new Error('Zendesk OAuth token response was invalid');
+  }
+
+  return result.data.access_token;
+}
+
+export interface ZendeskClientProvider {
+  run<T>(operation: (client: ZendeskClient) => Promise<T>): Promise<T>;
+}
+
+export async function createZendeskClientProvider(): Promise<ZendeskClientProvider> {
+  const env = getZendeskEnv();
+  const legacyClient = createLegacyClient(env);
+  let hasLoggedFallback = false;
+
+  const runWithLegacyFallback = async <T>(
+    reason: string,
+    operation: (client: ZendeskClient) => Promise<T>,
+  ): Promise<T> => {
+    if (!legacyClient) {
+      throw new Error(`Zendesk OAuth ${reason}, and no legacy fallback is configured`);
+    }
+
+    if (!hasLoggedFallback) {
+      console.warn(`Zendesk OAuth ${reason}; using deprecated API-token fallback`);
+      hasLoggedFallback = true;
+    }
+    return operation(legacyClient);
+  };
+
+  return {
+    async run<T>(operation: (zendeskClient: ZendeskClient) => Promise<T>): Promise<T> {
+      let accessToken: string;
+
+      try {
+        accessToken = await requestOAuthAccessToken(env);
+      } catch (error) {
+        if (!legacyClient) {
+          throw error;
+        }
+        return runWithLegacyFallback('token acquisition failed', operation);
+      }
+
+      const oauthClient = createClient({
+        token: accessToken,
+        oauth: true,
+        subdomain: env.ZENDESK_SUBDOMAIN,
+        throwOriginalException: true,
+      });
+
+      try {
+        return await operation(oauthClient);
+      } catch (error) {
+        if (isOAuthAuthorizationError(error) && legacyClient) {
+          return runWithLegacyFallback('request was rejected', operation);
+        }
+        throw error;
+      }
+    },
+  };
+}

--- a/webhook_setup/auth.sh
+++ b/webhook_setup/auth.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+# shellcheck disable=SC2034 # ZENDESK_HTTP_STATUS is consumed by scripts that source this file.
+
+ZENDESK_ACCESS_TOKEN=""
+ZENDESK_HTTP_STATUS=""
+ZENDESK_OAUTH_SCOPE=""
+ZENDESK_HAS_LOGGED_FALLBACK="false"
+
+zendesk_has_legacy_credentials() {
+    [ -n "$ZENDESK_API_USER" ] && [ -n "$ZENDESK_API_TOKEN" ]
+}
+
+zendesk_use_legacy_fallback() {
+    local reason="$1"
+
+    if ! zendesk_has_legacy_credentials; then
+        return 1
+    fi
+
+    if [ "$ZENDESK_HAS_LOGGED_FALLBACK" != "true" ]; then
+        echo "WARNING: Zendesk OAuth $reason; using deprecated API-token fallback" >&2
+        ZENDESK_HAS_LOGGED_FALLBACK="true"
+    fi
+    return 0
+}
+
+zendesk_initialize_auth() {
+    local scope="$1"
+
+    if [ -z "$ZENDESK_SUBDOMAIN" ] || [ -z "$ZENDESK_OAUTH_CLIENT_ID" ] || [ -z "$ZENDESK_OAUTH_CLIENT_SECRET" ]; then
+        echo "Error: ZENDESK_SUBDOMAIN, ZENDESK_OAUTH_CLIENT_ID, and ZENDESK_OAUTH_CLIENT_SECRET are required" >&2
+        return 1
+    fi
+
+    if { [ -n "$ZENDESK_API_USER" ] && [ -z "$ZENDESK_API_TOKEN" ]; } || \
+       { [ -z "$ZENDESK_API_USER" ] && [ -n "$ZENDESK_API_TOKEN" ]; }; then
+        echo "Error: ZENDESK_API_USER and ZENDESK_API_TOKEN must be provided together" >&2
+        return 1
+    fi
+
+    if ! command -v jq >/dev/null 2>&1; then
+        echo "Error: jq is required to parse the Zendesk OAuth response" >&2
+        return 1
+    fi
+
+    ZENDESK_OAUTH_SCOPE="$scope"
+}
+
+zendesk_request_access_token() {
+    local token_file
+    local curl_status
+
+    ZENDESK_ACCESS_TOKEN=""
+    token_file=$(mktemp)
+    curl_status=$(curl -sS -o "$token_file" -w "%{http_code}" \
+        -X POST "https://$ZENDESK_SUBDOMAIN.zendesk.com/oauth/tokens" \
+        -H "Content-Type: application/x-www-form-urlencoded" \
+        --data-urlencode "grant_type=client_credentials" \
+        --data-urlencode "client_id=$ZENDESK_OAUTH_CLIENT_ID" \
+        --data-urlencode "client_secret=$ZENDESK_OAUTH_CLIENT_SECRET" \
+        --data-urlencode "scope=$ZENDESK_OAUTH_SCOPE")
+    local curl_exit=$?
+
+    if [ "$curl_exit" -eq 0 ] && [[ "$curl_status" =~ ^2[0-9][0-9]$ ]]; then
+        ZENDESK_ACCESS_TOKEN=$(jq -r '.access_token // empty' "$token_file")
+    fi
+    rm -f "$token_file"
+
+    if [ -n "$ZENDESK_ACCESS_TOKEN" ]; then
+        return 0
+    fi
+
+    echo "Zendesk OAuth token acquisition failed with status ${curl_status:-unknown}" >&2
+    return 1
+}
+
+zendesk_request() {
+    local output_variable="$1"
+    shift
+    local response_file
+    local curl_status
+    local response_body
+    local request_auth_mode="oauth"
+
+    response_file=$(mktemp)
+    if ! zendesk_request_access_token; then
+        if zendesk_use_legacy_fallback "token acquisition failed"; then
+            request_auth_mode="legacy"
+        else
+            echo "Error: Zendesk OAuth token acquisition failed, and no legacy fallback is configured" >&2
+            rm -f "$response_file"
+            return 1
+        fi
+    fi
+
+    if [ "$request_auth_mode" = "oauth" ]; then
+        curl_status=$(curl -sS -o "$response_file" -w "%{http_code}" \
+            -H "Authorization: Bearer $ZENDESK_ACCESS_TOKEN" "$@")
+    else
+        curl_status=$(curl -sS -o "$response_file" -w "%{http_code}" \
+            -u "$ZENDESK_API_USER/token:$ZENDESK_API_TOKEN" "$@")
+    fi
+    local curl_exit=$?
+
+    if [ "$curl_exit" -ne 0 ]; then
+        rm -f "$response_file"
+        return "$curl_exit"
+    fi
+
+    if [ "$request_auth_mode" = "oauth" ] && { [ "$curl_status" = "401" ] || [ "$curl_status" = "403" ]; }; then
+        if zendesk_use_legacy_fallback "request was rejected"; then
+            curl_status=$(curl -sS -o "$response_file" -w "%{http_code}" \
+                -u "$ZENDESK_API_USER/token:$ZENDESK_API_TOKEN" "$@")
+            curl_exit=$?
+            if [ "$curl_exit" -ne 0 ]; then
+                rm -f "$response_file"
+                return "$curl_exit"
+            fi
+        fi
+    fi
+
+    response_body=$(<"$response_file")
+    rm -f "$response_file"
+    printf -v "$output_variable" '%s' "$response_body"
+    ZENDESK_HTTP_STATUS="$curl_status"
+}

--- a/webhook_setup/cleanup.sh
+++ b/webhook_setup/cleanup.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+ENV_FILE="$SCRIPT_DIR/../.env"
+RESOURCES_FILE="$SCRIPT_DIR/../.zendesk-resources"
+response=""
+
+# shellcheck source=webhook_setup/auth.sh
+source "$SCRIPT_DIR/auth.sh"
+
 echo "WARNING: This script will delete Zendesk resources from your instance."
 echo "Resources that will be deleted:"
 echo "- Webhook for Inkeep AI Response"
@@ -16,21 +24,26 @@ then
     exit 1
 fi
 # Load environment variables
-source ../.env
+if [ ! -f "$ENV_FILE" ]; then
+    echo "Error: .env file not found"
+    exit 1
+fi
+# shellcheck disable=SC1090
+source "$ENV_FILE"
 
 # Check if .zendesk-resources exists
-if [ ! -f "../.zendesk-resources" ]; then
+if [ ! -f "$RESOURCES_FILE" ]; then
     echo "Error: .zendesk-resources file not found"
     exit 1
 fi
 
 # Validate required environment variables
 missing_vars=()
-if [ -z "$ZENDESK_API_USER" ]; then
-    missing_vars+=("ZENDESK_API_USER")
+if [ -z "$ZENDESK_OAUTH_CLIENT_ID" ]; then
+    missing_vars+=("ZENDESK_OAUTH_CLIENT_ID")
 fi
-if [ -z "$ZENDESK_API_TOKEN" ]; then
-    missing_vars+=("ZENDESK_API_TOKEN")
+if [ -z "$ZENDESK_OAUTH_CLIENT_SECRET" ]; then
+    missing_vars+=("ZENDESK_OAUTH_CLIENT_SECRET")
 fi
 if [ -z "$ZENDESK_SUBDOMAIN" ]; then
     missing_vars+=("ZENDESK_SUBDOMAIN")
@@ -43,6 +56,10 @@ if [ ${#missing_vars[@]} -ne 0 ]; then
     exit 1
 fi
 
+if ! zendesk_initialize_auth "webhooks:write triggers:write"; then
+    exit 1
+fi
+
 # Read and process each line from .zendesk-resources
 while IFS='=' read -r key value; do
     # Skip empty lines
@@ -51,23 +68,29 @@ while IFS='=' read -r key value; do
     case "$key" in
         "WEBHOOK_ID")
             echo "Deleting webhook with ID: $value"
-            response=$(curl -s -u "$ZENDESK_API_USER/token:$ZENDESK_API_TOKEN" \
-                -X DELETE "https://$ZENDESK_SUBDOMAIN.zendesk.com/api/v2/webhooks/$value")
-            if [ -z "$response" ]; then
+            if ! zendesk_request response \
+                -X DELETE "https://$ZENDESK_SUBDOMAIN.zendesk.com/api/v2/webhooks/$value"; then
+                echo "Error contacting Zendesk while deleting webhook"
+                continue
+            fi
+            if [[ "$ZENDESK_HTTP_STATUS" =~ ^2[0-9][0-9]$ ]]; then
                 echo "Successfully deleted webhook"
             else
-                echo "Error deleting webhook: $response"
+                echo "Error deleting webhook (status $ZENDESK_HTTP_STATUS): $response"
             fi
             ;;
             
         "TRIGGER_ID")
             echo "Deleting trigger with ID: $value"
-            response=$(curl -s -u "$ZENDESK_API_USER/token:$ZENDESK_API_TOKEN" \
-                -X DELETE "https://$ZENDESK_SUBDOMAIN.zendesk.com/api/v2/triggers/$value.json")
-            if [ -z "$response" ]; then
+            if ! zendesk_request response \
+                -X DELETE "https://$ZENDESK_SUBDOMAIN.zendesk.com/api/v2/triggers/$value.json"; then
+                echo "Error contacting Zendesk while deleting trigger"
+                continue
+            fi
+            if [[ "$ZENDESK_HTTP_STATUS" =~ ^2[0-9][0-9]$ ]]; then
                 echo "Successfully deleted trigger"
             else
-                echo "Error deleting trigger: $response"
+                echo "Error deleting trigger (status $ZENDESK_HTTP_STATUS): $response"
             fi
             ;;
             
@@ -75,9 +98,8 @@ while IFS='=' read -r key value; do
             echo "Unknown resource type: $key"
             ;;
     esac
-done < "../.zendesk-resources"
+done < "$RESOURCES_FILE"
 
 # Remove the resources file after cleanup
-rm "../.zendesk-resources"
+rm "$RESOURCES_FILE"
 echo "Cleanup completed"
-

--- a/webhook_setup/setup.sh
+++ b/webhook_setup/setup.sh
@@ -1,10 +1,16 @@
 #!/bin/bash
 
 # Constants
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 WEBHOOK_NAME="Inkeep AI Response Webhook"
 TRIGGER_NAME="Inkeep Send New Ticket to AI Processing"
-RESOURCES_FILE="../.zendesk-resources"
-ENV_FILE="../.env"
+RESOURCES_FILE="$SCRIPT_DIR/../.zendesk-resources"
+ENV_FILE="$SCRIPT_DIR/../.env"
+webhook_response=""
+response=""
+
+# shellcheck source=webhook_setup/auth.sh
+source "$SCRIPT_DIR/auth.sh"
 
 echo "Starting Zendesk AutoResponder setup script..."
 echo "This script will set up the following resources in your Zendesk account:"
@@ -23,7 +29,7 @@ echo "- Detect new support tickets"
 echo "- Send ticket details to the AI processing endpoint"
 echo "- Generate and post AI responses back to tickets"
 echo ""
-read -p "Press Enter to continue or any other key to exit..." key
+read -r -p "Press Enter to continue or any other key to exit..." key
 
 if [[ $key != "" ]]; then
     echo "Setup cancelled"
@@ -38,25 +44,33 @@ if [ ! -f "$ENV_FILE" ]; then
 fi
 
 echo "=== Loading environment variables from .env file ==="
+# shellcheck disable=SC1090
 source "$ENV_FILE"
 
 echo "=== Validating required environment variables ==="
-if [ -z "$ZENDESK_API_USER" ] || [ -z "$ZENDESK_API_TOKEN" ] || [ -z "$ZENDESK_SUBDOMAIN" ] || [ -z "$AI_PROCESSING_ENDPOINT" ]; then
+if [ -z "$ZENDESK_OAUTH_CLIENT_ID" ] || [ -z "$ZENDESK_OAUTH_CLIENT_SECRET" ] || [ -z "$ZENDESK_SUBDOMAIN" ] || [ -z "$AI_PROCESSING_ENDPOINT" ]; then
     echo "Error: The following required environment variables must be set in .env file:"
-    echo "  - ZENDESK_API_USER: $ZENDESK_API_USER"
-    echo "  - ZENDESK_API_TOKEN: $ZENDESK_API_TOKEN" 
+    echo "  - ZENDESK_OAUTH_CLIENT_ID"
+    echo "  - ZENDESK_OAUTH_CLIENT_SECRET"
     echo "  - ZENDESK_SUBDOMAIN: $ZENDESK_SUBDOMAIN"
     echo "  - AI_PROCESSING_ENDPOINT: $AI_PROCESSING_ENDPOINT"
+    exit 1
+fi
+
+if ! zendesk_initialize_auth "webhooks:read webhooks:write triggers:read triggers:write"; then
     exit 1
 fi
 
 echo "=== Starting webhook setup process ==="
 if [ -n "$AI_RESPONDER_WEBHOOK_ID" ]; then
     echo "=== Verifying existing webhook ==="
-    webhook_response=$(curl -s -u "$ZENDESK_API_USER/token:$ZENDESK_API_TOKEN" \
-      -X GET "https://$ZENDESK_SUBDOMAIN.zendesk.com/api/v2/webhooks/$AI_RESPONDER_WEBHOOK_ID.json")
+    if ! zendesk_request webhook_response \
+      -X GET "https://$ZENDESK_SUBDOMAIN.zendesk.com/api/v2/webhooks/$AI_RESPONDER_WEBHOOK_ID.json"; then
+        echo "Error: Failed to contact Zendesk while verifying the webhook"
+        exit 1
+    fi
     
-    if [[ "$webhook_response" == *"\"error\""* ]]; then
+    if [[ ! "$ZENDESK_HTTP_STATUS" =~ ^2[0-9][0-9]$ ]] || [[ "$webhook_response" == *"\"error\""* ]]; then
         echo "Error: Provided webhook ID does not exist"
         exit 1
     fi
@@ -77,12 +91,15 @@ else
 EOF
 )
 
-    webhook_response=$(curl -s -u "$ZENDESK_API_USER/token:$ZENDESK_API_TOKEN" \
+    if ! zendesk_request webhook_response \
       -X POST "https://$ZENDESK_SUBDOMAIN.zendesk.com/api/v2/webhooks" \
       -H "Content-Type: application/json" \
-      -d "$webhook_data")
+      -d "$webhook_data"; then
+        echo "Error: Failed to contact Zendesk while creating the webhook"
+        exit 1
+    fi
       
-    if [[ "$webhook_response" == *"\"error\""* ]]; then
+    if [[ ! "$ZENDESK_HTTP_STATUS" =~ ^2[0-9][0-9]$ ]] || [[ "$webhook_response" == *"\"error\""* ]]; then
         echo "Error creating webhook:"
         echo "$webhook_response"
         exit 1
@@ -142,12 +159,15 @@ EOF
 )
 
 echo "=== Creating Zendesk trigger ==="
-response=$(curl -s -u "$ZENDESK_API_USER/token:$ZENDESK_API_TOKEN" \
+if ! zendesk_request response \
   -X POST "https://$ZENDESK_SUBDOMAIN.zendesk.com/api/v2/triggers.json" \
   -H "Content-Type: application/json" \
-  -d "$trigger_data")
+  -d "$trigger_data"; then
+    echo "Error: Failed to contact Zendesk while creating the trigger"
+    exit 1
+fi
 
-if [[ "$response" == *"\"id\""* ]]; then
+if [[ "$ZENDESK_HTTP_STATUS" =~ ^2[0-9][0-9]$ ]] && [[ "$response" == *"\"id\""* ]]; then
     trigger_id=$(echo "$response" | grep -o '"id":[0-9]*' | cut -d':' -f2)
     echo "Trigger created successfully with ID: $trigger_id"
     

--- a/webhook_setup/verify.sh
+++ b/webhook_setup/verify.sh
@@ -1,17 +1,26 @@
 #!/bin/bash
 
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+ENV_FILE="$SCRIPT_DIR/../.env"
+webhooks_response=""
+triggers_response=""
+
+# shellcheck source=webhook_setup/auth.sh
+source "$SCRIPT_DIR/auth.sh"
+
 # Check if .env file exists in parent directory
-if [ ! -f "../.env" ]; then
+if [ ! -f "$ENV_FILE" ]; then
     echo "Error: .env file not found in parent directory"
     exit 1
 fi
 
 # Load environment variables from .env file in parent directory
-source "../.env"
+# shellcheck disable=SC1090
+source "$ENV_FILE"
 
 # Check if required variables are set
-if [ -z "$ZENDESK_API_USER" ] || [ -z "$ZENDESK_API_TOKEN" ] || [ -z "$AI_PROCESSING_ENDPOINT" ]; then
-    echo "Error: ZENDESK_API_USER, ZENDESK_API_TOKEN, and AI_PROCESSING_ENDPOINT must be set in .env file"
+if [ -z "$ZENDESK_OAUTH_CLIENT_ID" ] || [ -z "$ZENDESK_OAUTH_CLIENT_SECRET" ] || [ -z "$ZENDESK_SUBDOMAIN" ] || [ -z "$AI_PROCESSING_ENDPOINT" ]; then
+    echo "Error: ZENDESK_OAUTH_CLIENT_ID, ZENDESK_OAUTH_CLIENT_SECRET, ZENDESK_SUBDOMAIN, and AI_PROCESSING_ENDPOINT must be set in .env file"
     exit 1
 fi
 
@@ -23,17 +32,24 @@ if ! command -v jq &> /dev/null; then
     exit 1
 fi
 
+if ! zendesk_initialize_auth "webhooks:read triggers:read"; then
+    exit 1
+fi
+
 # First, get all webhooks
 echo "Fetching webhooks..."
-webhooks_response=$(curl -s -i -u "$ZENDESK_API_USER/token:$ZENDESK_API_TOKEN" \
-  -X GET "https://$ZENDESK_SUBDOMAIN.zendesk.com/api/v2/webhooks")
+if ! zendesk_request webhooks_response \
+  -X GET "https://$ZENDESK_SUBDOMAIN.zendesk.com/api/v2/webhooks"; then
+    echo "Error: Failed to contact Zendesk while fetching webhooks"
+    exit 1
+fi
 
 # Echo full response for debugging
 echo "Full Response:"
 echo "$webhooks_response"
 
 # Check HTTP status code
-http_status=$(echo "$webhooks_response" | head -n 1 | cut -d' ' -f2)
+http_status="$ZENDESK_HTTP_STATUS"
 
 if [ "$http_status" != "200" ]; then
     echo "Error: Failed to fetch webhooks. Status code: $http_status"
@@ -46,8 +62,7 @@ if [ "$http_status" != "200" ]; then
     exit 1
 fi
 
-# Extract JSON body (skip headers) - improved version
-json_response=$(echo "$webhooks_response" | sed -n '/^{/,$p')
+json_response="$webhooks_response"
 
 # Debug webhook response
 echo "Debug - Webhook Response:"
@@ -66,8 +81,17 @@ fi
 
 # Get all active triggers
 echo "Fetching triggers..."
-triggers_response=$(curl -s -u "$ZENDESK_API_USER/token:$ZENDESK_API_TOKEN" \
-  -X GET "https://$ZENDESK_SUBDOMAIN.zendesk.com/api/v2/triggers/active.json")
+if ! zendesk_request triggers_response \
+  -X GET "https://$ZENDESK_SUBDOMAIN.zendesk.com/api/v2/triggers/active.json"; then
+    echo "Error: Failed to contact Zendesk while fetching triggers"
+    exit 1
+fi
+
+if [ "$ZENDESK_HTTP_STATUS" != "200" ]; then
+    echo "Error: Failed to fetch triggers. Status code: $ZENDESK_HTTP_STATUS"
+    echo "$triggers_response"
+    exit 1
+fi
 
 # Echo raw response
 echo "Raw Triggers Response:"


### PR DESCRIPTION
- request a fresh OAuth token before each Zendesk API operation
- retain deprecated API-token credentials as a temporary fallback
- add least-privilege runtime and provisioning scopes
- update webhook lifecycle scripts to authenticate with OAuth
- validate required OAuth environment variables
- document Zendesk API-token retirement and migration setup

https://support.zendesk.com/hc/en-us/articles/4408889192858-Managing-API-token-access-to-the-Zendesk-API

> Note: Zendesk is removing API tokens as an authentication method. Starting July 28, 2026, tokens unused for 30 days will be automatically deleted. By April 30, 2027, all API tokens will stop working. You must [migrate your integrations to OAuth access tokens](https://developer.zendesk.com/documentation/api-basics/authentication/oauth-migration/) before the final deadline. This change only affects APIs that currently use API tokens including the Ticketing, Help Center, and Voice APIs. It does not apply to other Zendesk products.